### PR TITLE
Use element.remove() fallback for IE compatibility

### DIFF
--- a/responsive_waterfall.js
+++ b/responsive_waterfall.js
@@ -124,7 +124,7 @@
         // remove old column
         for (var i = 0; i < this.columns.length; i++) {
           var columnElem = this.columns[i];
-          columnElem.remove();
+          this.container.removeChild(columnElem);
         }
 
         // init new column


### PR DESCRIPTION
First of all, thanks for your great work on this library! We use it in production at Goshen College.

I've done some Internet Explorer testing and have a one-liner bugfix:
Replace `columnElem.remove()` with `this.container.removeChild(columnElem)`, since Element.remove() syntax isn't supported by IE.